### PR TITLE
Fix contact page HTML comment

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -65,6 +65,7 @@
             </form>
         </div>
     </section>
+   -->
 
     <!-- Contact Page Content -->
     <main class="main-content">


### PR DESCRIPTION
## Summary
- close the old contact section comment to prevent entire page markup from being commented out

## Testing
- `grep -n -- '-->' contact.html | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_686d33b764f88321a3baaddde19eda41