### PR TITLE
Add maintenance script for freshness audit

### DIFF
--- a/.github/workflows/freshness-audit.yml
+++ b/.github/workflows/freshness-audit.yml
@@ -1,0 +1,42 @@
+name: Freshness Audit
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: node scripts/freshness-audit.js > audit.json
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const data = JSON.parse(fs.readFileSync('audit.json', 'utf8'));
+            const issueTitle = 'Content Freshness Audit';
+            const bodyLines = ['## Stale Content', ''];
+            if (data.staleItems.length === 0) {
+              bodyLines.push('All checked items are fresh.');
+            } else {
+              for (const item of data.staleItems) {
+                bodyLines.push(`- **${item.name}** (${item.file}) - Last updated ${item.lastUpdated} (${item.ageDays} days ago)`);
+              }
+            }
+            const body = bodyLines.join('\n');
+
+            const { data: issues } = await github.rest.issues.listForRepo({ owner, repo, state: 'open' });
+            const existing = issues.find(i => i.title === issueTitle);
+            if (existing) {
+              await github.rest.issues.update({ owner, repo, issue_number: existing.number, body });
+            } else {
+              await github.rest.issues.create({ owner, repo, title: issueTitle, body, labels: ['automation'] });
+            }
+

--- a/docs/freshness-issue-template.md
+++ b/docs/freshness-issue-template.md
@@ -1,0 +1,8 @@
+## Stale Content
+
+The automated freshness audit found outdated content:
+
+- **FAQ Page** (faq.html) - Last updated YYYY-MM-DD (NNN days ago)
+- **Location Page** (contact.html) - Last updated YYYY-MM-DD (NNN days ago)
+
+Please review these pages and update any outdated information.

--- a/scripts/freshness-audit.js
+++ b/scripts/freshness-audit.js
@@ -1,0 +1,42 @@
+const { execSync } = require('child_process');
+
+// Pages to audit with friendly names
+const pages = [
+  { file: 'faq.html', name: 'FAQ Page' },
+  { file: 'contact.html', name: 'Location Page' }
+];
+
+function getLastCommitDate(file) {
+  try {
+    const result = execSync(`git log -1 --format=%cI -- "${file}"`, { encoding: 'utf8' }).trim();
+    return new Date(result);
+  } catch (err) {
+    return null;
+  }
+}
+
+function daysBetween(date) {
+  const msPerDay = 1000 * 60 * 60 * 24;
+  return Math.floor((Date.now() - date.getTime()) / msPerDay);
+}
+
+const staleItems = [];
+
+for (const page of pages) {
+  const lastDate = getLastCommitDate(page.file);
+  if (!lastDate) {
+    // Skip if file not found or git command failed
+    continue;
+  }
+  const age = daysBetween(lastDate);
+  if (age > 180) {
+    staleItems.push({
+      name: page.name,
+      file: page.file,
+      lastUpdated: lastDate.toISOString().split('T')[0],
+      ageDays: age
+    });
+  }
+}
+
+console.log(JSON.stringify({ staleItems }, null, 2));


### PR DESCRIPTION
## Summary
- add Node script `freshness-audit.js` to check last commit of FAQ and contact pages
- create GitHub workflow to run audit monthly and update an issue
- document sample issue template

## Testing
- `node scripts/freshness-audit.js`

------
https://chatgpt.com/codex/tasks/task_e_687b6649ef808321b669bad9223df08e