### PR TITLE
Add Lighthouse CI budget to enforce performance

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,22 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Audit with Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v9
+        with:
+          configPath: ./lighthouserc.json
+          budgetPath: ./perf-budget.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,15 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": ".",
+      "numberOfRuns": 1
+    },
+    "assert": {
+      "assertions": {
+        "largest-contentful-paint": ["error", {"maxNumericValue": 2500}],
+        "interaction-to-next-paint": ["error", {"maxNumericValue": 200}],
+        "cumulative-layout-shift": ["error", {"maxNumericValue": 0.1}]
+      }
+    }
+  }
+}

--- a/perf-budget.json
+++ b/perf-budget.json
@@ -1,0 +1,10 @@
+[
+  {
+    "path": "/*",
+    "resourceSizes": [
+      {"resourceType": "image", "budget": 600},
+      {"resourceType": "script", "budget": 300},
+      {"resourceType": "stylesheet", "budget": 150}
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add Lighthouse CI workflow and Node setup
- define strict performance assertions
- set a performance budget

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687b6714ccf08321bf06c69891e27f93